### PR TITLE
added check for stats_filepath presence in rtl_airband.conf

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/03-rtl_airband
+++ b/rootfs/etc/s6-overlay/scripts/03-rtl_airband
@@ -6,7 +6,8 @@ if [ -z "$RTLSDRAIRBAND_CUSTOMCONFIG" ]; then
 	sed -i "s/gain = [^<]*; # device 1/gain = $RTLSDRAIRBAND_GAIN; # device 1/g" /usr/local/etc/rtl_airband.conf
 
 	if [ -n "${ENABLE_PROMETHEUS}" ]; then
-		sed -i "1istats_filepath = \"/tmp/rtl_airband_stats.txt\";" /usr/local/etc/rtl_airband.conf
+		grep -qv "stats_filepath = \"/tmp/rtl_airband_stats.txt\";" /usr/local/etc/rtl_airband.conf && \
+			sed -i "1istats_filepath = \"/tmp/rtl_airband_stats.txt\";" /usr/local/etc/rtl_airband.conf
 	fi
 
 	if [ -n "${RTLSDRAIRBAND_CORRECTION}" ]; then


### PR DESCRIPTION
otherwise that line is being duplicated on unsafe container restart (reboot of host, killing container, etc) and RTL_airband being unable to start.
In case commands like `docker compose down && docker compose up -d` would be used - duplication doesn't happens.
![image](https://github.com/sdr-enthusiasts/docker-rtlsdrairband/assets/19597706/5baa5731-56ef-4abf-a9eb-96b6b479e7b3)
![image](https://github.com/sdr-enthusiasts/docker-rtlsdrairband/assets/19597706/aa8e3993-99d7-46ba-a755-74431eeddfe5)
