### PR TITLE
Fix docker image for rtlsdr_airband 5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -319,6 +319,15 @@ RUN set -x && \
   make install && \
   popd && popd && \
   ldconfig && \
+  # Deploy libmirisdr-4
+  git clone https://github.com/f4exb/libmirisdr-4 /src/libmirisdr-4 && \
+  pushd /src/libmirisdr-4 && \
+  mkdir -p /src/libmirisdr-4/build && \
+  pushd /src/libmirisdr-4/build && \
+  cmake ../ && \
+  VERBOSE=1 make install && \
+  popd && popd && \
+  ldconfig && \
   # # install S6 Overlay
   # curl -o /tmp/deploy-s6-overlay.sh https://raw.githubusercontent.com/mikenye/deploy-s6-overlay/master/deploy-s6-overlay.sh && \
   # bash -x /tmp/deploy-s6-overlay.sh && \
@@ -360,14 +369,17 @@ RUN set -x && \
   KEPT_PACKAGES+=(libvorbis-dev) && \
   KEPT_PACKAGES+=(make) && \
   KEPT_PACKAGES+=(cmake) && \
+  KEPT_PACKAGES+=(libusb-1.0-0-dev) && \
+  KEPT_PACKAGES+=(libpulse-dev) && \
+  KEPT_PACKAGES+=(git) && \
   apt-get install -y --no-install-recommends \
   ${KEPT_PACKAGES[@]} \
   && \
   # Now compile and install rtlsdr_airband
   /scripts/build-rtl_airband.sh && \
   # Clean up
-  apt-get clean && \
-  rm -rf /src/* /tmp/* /var/lib/apt/lists/*
+ apt-get clean && \
+ rm -rf /src/* /tmp/* /var/lib/apt/lists/*
 
 ENTRYPOINT [ "/init" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -378,8 +378,8 @@ RUN set -x && \
   # Now compile and install rtlsdr_airband
   /scripts/build-rtl_airband.sh && \
   # Clean up
- apt-get clean && \
- rm -rf /src/* /tmp/* /var/lib/apt/lists/*
+  apt-get clean && \
+  rm -rf /src/* /tmp/* /var/lib/apt/lists/*
 
 ENTRYPOINT [ "/init" ]
 

--- a/rootfs/etc/s6-overlay/scripts/01-build-rtl_airband
+++ b/rootfs/etc/s6-overlay/scripts/01-build-rtl_airband
@@ -38,7 +38,7 @@ else
             # If not available, build with no optimisations.
             # This should never happen, as it's included in the Dockerfile.
             echo "ERROR: 'file' (libmagic) not available, cannot detect architecture! Will build with no optimisations."
-            CMAKE_CMD+=("-DPLATFORM=default")
+            CMAKE_CMD+=("-DPLATFORM=generic")
 
         else
 
@@ -88,16 +88,16 @@ else
                 # /usr/bin/file: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, stripped
                 # /usr/bin/file: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=a8d6092fd49d8ec9e367ac9d451b3f55c7ae7a78, stripped
                 if echo "${FILEOUTPUT}" | grep "aarch64" > /dev/null; then
-                    echo "Building with \"armv8-generic\" optimisations."
-                    CMAKE_CMD+=("-DPLATFORM=armv8-generic")
+                    echo "Building with \"generic\" optimisations."
+                    CMAKE_CMD+=("-DPLATFORM=generic")
                 fi
 
             fi
 
             # If we don't have an architecture at this point, there's been a problem and we can't continue
-            if [ -z "${ARCH}" ]; then
+            if ! [[ ${CMAKE_CMD[*]} =~ 'DPLATFORM' ]]; then
                 echo "WARNING: Unable to determine architecture, will build with no optimisations."
-                CMAKE_CMD+=("-DPLATFORM=default")
+                CMAKE_CMD+=("-DPLATFORM=generic")
             fi
         fi
     fi

--- a/rootfs/scripts/build-rtl_airband.sh
+++ b/rootfs/scripts/build-rtl_airband.sh
@@ -38,7 +38,7 @@ else
             # If not available, build with no optimisations.
             # This should never happen, as it's included in the Dockerfile.
             echo "ERROR: 'file' (libmagic) not available, cannot detect architecture! Will build with no optimisations."
-            CMAKE_CMD+=("-DPLATFORM=default")
+            CMAKE_CMD+=("-DPLATFORM=generic")
 
         else
 
@@ -88,16 +88,16 @@ else
                 # /usr/bin/file: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, stripped
                 # /usr/bin/file: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=a8d6092fd49d8ec9e367ac9d451b3f55c7ae7a78, stripped
                 if echo "${FILEOUTPUT}" | grep "aarch64" > /dev/null; then
-                    echo "Building with \"armv8-generic\" optimisations."
-                    CMAKE_CMD+=("-DPLATFORM=armv8-generic")
+                    echo "Building with \"generic\" optimisations."
+                    CMAKE_CMD+=("-DPLATFORM=generic")
                 fi
 
             fi
 
             # If we don't have an architecture at this point, there's been a problem and we can't continue
-            if [ -z "${ARCH}" ]; then
+            if ! [[ ${CMAKE_CMD[*]} =~ 'DPLATFORM' ]]; then
                 echo "WARNING: Unable to determine architecture, will build with no optimisations."
-                CMAKE_CMD+=("-DPLATFORM=default")
+                CMAKE_CMD+=("-DPLATFORM=generic")
             fi
         fi
     fi


### PR DESCRIPTION
The latest docker image is broken as it can no longer build version 5+ of rtlsdr_airband on first start. This PR fixes docker image to work with the new version.

```
s6-rc: info: service s6rc-oneshot-runner: starting
s6-rc: info: service s6rc-oneshot-runner successfully started
s6-rc: info: service fix-attrs: starting
s6-rc: info: service libseccomp2: starting
s6-rc: info: service 01-build-rtl_airband: starting
s6-rc: info: service fix-attrs successfully started
s6-rc: info: service legacy-cont-init: starting
Building rtl_airband optimised for this host's CPU
s6-rc: info: service libseccomp2 successfully started
s6-rc: info: service legacy-cont-init successfully started
Building with "native" optimisations.
WARNING: Unable to determine architecture, will build with no optimisations.
[building rtlair_band: cmake] CMake Error at CMakeLists.txt:13 (message):
[building rtlair_band: cmake]   Failed to detect RTL_AIRBAND_VERSION -
[building rtlair_band: cmake]   "/opt/rtlsdr-airband/scripts/find_version: line 9: git: command not found"
[building rtlair_band: cmake] -- Configuring incomplete, errors occurred!
[building rtlair_band: cmake] See also "/opt/rtlsdr-airband/build/CMakeFiles/CMakeOutput.log".
[building rtlair_band: make] make: *** No targets specified and no makefile found.  Stop.
[building rtlair_band: make install] make: *** No rule to make target 'install'.  Stop.
s6-rc: info: service 01-build-rtl_airband successfully started
```


- With rtlsdr_airband 5.0.0, `armv7-generic` and `armv8-generic` builds are no longer supported and are replaced with `generic`. See https://github.com/charlie-foxtrot/RTLSDR-Airband/discussions/447. I've remapped those to `generic`.  I'm not sure the `armhf` and `aarch64` detection is completely correct as is - seems to me that `aarch64` could be a 64bit Raspberry Pi and could use the GPU FFT optimization, but for this PR, I'm just remapping the depreciated builds to `generic` to be safe. 
- Added dependency needed to build rtlsdr-airband and made sure those dependency are available for first start build in the case of NFM_MAKE. 
